### PR TITLE
fix(settings.py): remove STATICFILES_DIRS as it breaks static files paths

### DIFF
--- a/src/dossier_search/dossier_search/settings.py
+++ b/src/dossier_search/dossier_search/settings.py
@@ -60,11 +60,7 @@ STATICFILES_DIRS = [
     STATIC_DIR,
 ]
 
-
 SITE_ROOT = os.path.dirname(os.path.realpath(__file__))
-# STATIC_ROOT = (os.path.join(SITE_ROOT, 'static_files/'))
-STATICFILES_DIRS = (os.path.join(SITE_ROOT, "static/"),)
-
 
 TEMPLATES = [
     {


### PR DESCRIPTION
Setting `STATICFILES_DIRS` breaks paths to static files resulting in 404. Simply removing it fixes the problem. 