### PR TITLE
feat(Concept Map): add concept map on frontend

### DIFF
--- a/src/dossier_search/static/css/style.css
+++ b/src/dossier_search/static/css/style.css
@@ -98,3 +98,7 @@
   display: flex;
   margin: 10px 0;
 }
+
+.concept-map__row a {
+  margin: 0 5px;
+}

--- a/src/dossier_search/templates/_concept_map.html
+++ b/src/dossier_search/templates/_concept_map.html
@@ -2,31 +2,31 @@
     <div class="concept-map__row">
         {% for parent in concept.parents %}
             {% for subparent in parent.parents %}
-                <a href="#" class="button is-small">{{ subparent.title }}</a>
+                <a href="{% url 'search_results' %}?search_query={{ subparent.title | urlencode }}" class="button is-small">{{ subparent.title }}</a>
             {% endfor %}
         {% endfor %}
     </div>
 
     <div class="concept-map__row">
         {% for parent in concept.parents %}
-            <a href="#" class="button">{{ parent.title }}</a>
+            <a href="{% url 'search_results' %}?search_query={{ parent.title | urlencode }}" class="button">{{ parent.title }}</a>
         {% endfor %}
     </div>
 
     <div class="concept-map__row">
-        <a href="#" class="button is-medium">{{ concept.title }}</a><br>
+        <a href="{% url 'search_results' %}?search_query={{ concept.title | urlencode }}" class="button is-medium">{{ concept.title }}</a><br>
     </div>
 
     <div class="concept-map__row">
         {% for child in concept.children %}
-            <a href="#" class="button">{{ child.title }}</a>
+            <a href="{% url 'search_results' %}?search_query={{ child.title | urlencode }}" class="button">{{ child.title }}</a>
         {% endfor %}
     </div>
 
     <div class="concept-map__row">
         {% for child in concept.children %}
             {% for subchild in child.children %}
-                <a href="#" class="button is-small">{{ subchild.title }}</a>
+                <a href="{% url 'search_results' %}?search_query={{ subchild.title | urlencode }}" class="button is-small">{{ subchild.title }}</a>
             {% endfor %}
         {% endfor %}
     </div>


### PR DESCRIPTION
## Description

Add a basic concept map rendered using only buttons (no arrows yet). See the right rectangle on screenshot for a reference.

## Screenshot

<img width="1402" alt="Screenshot 2022-03-22 at 18 33 00" src="https://user-images.githubusercontent.com/1566128/159541137-7cb3470d-e50c-4709-b34d-786e75390808.png">

