### PR TITLE
fix(wikipedia): catch KeyError exception from `wikipedia` package in case of some pages

### DIFF
--- a/src/dossier_search/engine/search_wikipedia.py
+++ b/src/dossier_search/engine/search_wikipedia.py
@@ -19,6 +19,8 @@ def search_wikipedia(query: str) -> Union[Dict[str, str], None]:
         )
     except wikipedia.PageError:
         result = None
+    except KeyError:
+        result = None
     except wikipedia.DisambiguationError as e:
         page_object = wikipedia.page(e.options[0], auto_suggest=False)
 


### PR DESCRIPTION
`wikipedia` package throws KeyError exception for some pages if URL was not found, e.g. queries `[` or `]`.
The easiest way is to catch this exception and return `None` object result

This fixes #48 