### PR TITLE
fix(search): empty query search redirects to homepage

### DIFF
--- a/src/dossier_search/engine/views.py
+++ b/src/dossier_search/engine/views.py
@@ -51,6 +51,13 @@ def about(request):
 def search_results(request):
     if request.method == "GET":
         search_query = request.GET.get("search_query", None)
+
+        if not search_query:
+            return render(
+                request,
+                "interfaces/home.html",
+            )
+
         logger.info(search_query)
 
         index_name = "papers"


### PR DESCRIPTION
Previously when a user clicked the search button with an empty query we got a KeyError. Currently it will just reload the homepage.

fixes #53 